### PR TITLE
include simple CSRF protection to login form

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -26,3 +26,6 @@ body {
   background-color: #f5f5f5;
 }
 
+.error {
+  color: red;
+}

--- a/templates/login_page.html
+++ b/templates/login_page.html
@@ -2,11 +2,15 @@
 {% block content %}
 <body>
     <form action="/login" method="post" accept-charset="utf-8">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}"/>
         <p>Username:</p>
         <input type="text" name="username" />
         <p>Password:</p>
         <input type="password" name="password" /> <br>
         <input type="submit" value="Login" />
+        {% if error %}
+        <p class="error">Error while logging in: {{ error }}</p>
+        {% endif %}
     </form>
 </body>
 {% endblock %}


### PR DESCRIPTION
Simple CSRF mechanism to the login form, in order to show how `FormRequest.from_response()` is useful.
