### PR TITLE
Add Google Analytics Tracking Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Analytics](https://ga-beacon-shub.appspot.com/UA-20306421-8/spidyquotes?useReferrer)](https://github.com/igrigorik/ga-beacon)
-
-
 # Spidy quotes
 
 This is an example site for a web scraping tutorial
@@ -11,3 +8,6 @@ This is an example site for a web scraping tutorial
     python spidyquotes.py
 
 To run in development mode, use the `--debug` flag.
+
+[![Analytics](https://ga-beacon-shub.appspot.com/UA-20306421-8/spidyquotes?useReferrer&pixel)](https://github.com/igrigorik/ga-beacon)
+[![Analytics](https://ga-beacon-shub.appspot.com/UA-20306421-7/spidyquotes?useReferrer&pixel)](https://github.com/igrigorik/ga-beacon)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![Analytics](https://ga-beacon-shub.appspot.com/UA-20306421-8
-/spidyquotes?useReferrer)
+[![Analytics](https://ga-beacon-shub.appspot.com/UA-20306421-8/spidyquotes?useReferrer)](https://github.com/igrigorik/ga-beacon)
 
 
 # Spidy quotes

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![Analytics](https://ga-beacon-shub.appspot.com/UA-20306421-8
+/spidyquotes?useReferrer)
+
+
 # Spidy quotes
 
 This is an example site for a web scraping tutorial


### PR DESCRIPTION
This PR includes a Google Analytics tracking pixel in this repository's README, so that we can track which of our websites' page views are coming via open source projects.

For more information, see: https://github.com/scrapinghub/ga-beacon
